### PR TITLE
Use new value of STATE_DB FAST_REBOOT entry

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -49,7 +49,8 @@ case "$(cat /proc/cmdline)" in
     ;;
   *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
     # check that the key exists
-    if [[ $(sonic-db-cli STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
        FAST_REBOOT='yes'
     else
        FAST_REBOOT='no'


### PR DESCRIPTION
Update syncd_init_common to check if fast-reboot is enabled according to the new value for FAST_REBOOT entry in STATE_DB.

This PR is similar to 1196 and is dedicated to 202211.