### PR TITLE
Use temp view also in fast-reboot

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -26,10 +26,8 @@ else
     CMD_ARGS=
 fi
 
-# Use temporary view between init and apply except when in fast-reboot
-if [[ "$(cat /proc/cmdline)" != *"SONIC_BOOT_TYPE=fast-reboot"* ]]; then
-    CMD_ARGS+=" -u"
-fi
+# Use temporary view between init view and apply view
+CMD_ARGS+=" -u"
 
 # Create a folder for SAI failure dump files
 mkdir -p /var/log/sai_failure_dump/


### PR DESCRIPTION
syncd_init_common.sh is checking fast-reboot by reading /proc/cmdline. However, /proc/cmdline will not change after config reload. So, consider a case like fast-reboot -> config reload. In the config reload process, syncd_init_common.sh will also treat it as fast-reboot and probably enter wrong logic.